### PR TITLE
feat: add covSPECTRUM to dashboards

### DIFF
--- a/_data/resources.yaml
+++ b/_data/resources.yaml
@@ -34,6 +34,12 @@
   subheading: Emma Hodcroft, University of Bern, Switzerland
   logourl: covariants.png
   category: Dashboards
+- name: covSPECTRUM
+  link: https://cov-spectrum.ethz.ch//
+  description: An interactive dashboard SARS-CoV-2 variants with sophisticated queries
+  subheading: Computational Evolution group at ETH Zurich, Switzerland
+  logourl: https://cov-spectrum.ethz.ch/
+  category: Dashboards
 - name: PanGUIlin
   link: https://pangolin.cog-uk.io/
   description: A web application version of the Pangolin Tool


### PR DESCRIPTION
covSpectrum is superior to both outbreak.info and covariants.org in terms of querying options.

For example, a pango lineage can be queried with a wildcard, including all descendant lineages: `B.1.617.2*` also includes all `AY*`.

It is also updated with new data much faster (within hours of new GISAID data) than outbreak.info and covariants (which take 1-3 days).

For further information contact @chaoran-chen

Declaration of Interests: 
- I have contributed code to all 3 websites
- I am employed at Biozentrum in the group that covariants was conceived