### PR TITLE
List simple installation using `conda -c bioconda pangolin`

### DIFF
--- a/resources/pangolin/installation.html
+++ b/resources/pangolin/installation.html
@@ -4,6 +4,16 @@ layout: default
 
 <h1>Installation</h1>
 
+<h2>Using Bioconda</h2>
+
+<ol class="listWithCode">
+	<li> Install using conda (or mamba) <span class="code">conda install -c bioconda pangolin</span></li>
+	<li> Try it out <span class="code">pangolin -h</span></li>
+	<li> That's it!</li>
+</ol>
+
+<h2>For development</h2>
+
 <ol class="listWithCode">
 	<li> Clone the pangolin repository and <span class="code">cd pangolin</span></li>
 	<li> <span class="code">conda env create -f environment.yml</span></li>

--- a/resources/pangolin/installation.html
+++ b/resources/pangolin/installation.html
@@ -7,7 +7,7 @@ layout: default
 <h2>Using Bioconda</h2>
 
 <ol class="listWithCode">
-	<li> Install using conda (or mamba) <span class="code">conda install -c bioconda pangolin</span></li>
+	<li> Install using conda (or mamba) <span class="code">conda install -c bioconda -c conda-forge -c defaults pangolin</span></li>
 	<li> Try it out <span class="code">pangolin -h</span></li>
 	<li> That's it!</li>
 </ol>


### PR DESCRIPTION
I wasn't aware there's a bioconda recipe for pangolin. That makes installation much easier. I don't see why this shouldn't be mentioned in the docs.

Basically solves this issue: https://github.com/cov-lineages/pangolin/pull/269