### PR TITLE
Standardize capitalizaton (Pango not PANGO) in navigation bar and two pages

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -4,7 +4,7 @@
   </li>
   <li class="nav-item dropdown">
     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      PANGO
+      Pango
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
       <a class="dropdown-item" href="{{'/index.html#about' | absolute_url}}">About</a>
@@ -49,7 +49,7 @@
         <ul>
             <li><a class="nested-nav-item" href="{{ 'index.html' | absolute_url }}">Home</a></li>
             <li>
-               <div class="nested-nav-item">PANGO</div>
+               <div class="nested-nav-item">Pango</div>
                 <ul>
                     <li><a class="nested-nav-item" href="{{'/index.html#about' | absolute_url}}">About</a></li>
                     <li><a class="nested-nav-item" href="{{'/FAQ.html' | absolute_url}}">FAQs</a></li>

--- a/lineage_list.html
+++ b/lineage_list.html
@@ -18,7 +18,7 @@ children: ['A', 'A.1', 'A.2', 'A.2.1', 'A.2.2', 'A.2.3', 'A.2.4', 'A.2.5', 'A.2.
 
   <header class="main">
 		<h1>{{ page.title }}</h1>
-                <p>This is a list of active lineages which have been seen in the last year. A complete list of lineages can be found on <a href="https://github.com/cov-lineages/pango-designation">the PANGO designation GitHub</a> and a JSON file containing the equivalent data from this page for the full set of lineages can be downloaded in JSON format <a href="https://github.com/cov-lineages/lineages-website/blob/master/_data/lineage_data.full.json">here</a>.</p>    
+                <p>This is a list of active lineages which have been seen in the last year. A complete list of lineages can be found on <a href="https://github.com/cov-lineages/pango-designation">the Pango designation GitHub</a> and a JSON file containing the equivalent data from this page for the full set of lineages can be downloaded in JSON format <a href="https://github.com/cov-lineages/lineages-website/blob/master/_data/lineage_data.full.json">here</a>.</p>    
 
     
 	</header>

--- a/resources/civet/map_options.html
+++ b/resources/civet/map_options.html
@@ -40,9 +40,9 @@ Arguments:<br>
 <h2>Mapping background diversity (report option 7)</h2>
 
 
-<p>This option summarises the PANGO lineages as radial charts during a set time period at a specific geographical level. Only lineages that make up more than 5% of the overall sequence count are shown, with others shown under “other”.</p>
+<p>This option summarises the Pango lineages as radial charts during a set time period at a specific geographical level. Only lineages that make up more than 5% of the overall sequence count are shown, with others shown under “other”.</p>
  
-<p>For more information on PANGO lineages, see https://www.pango.network/</p>
+<p>For more information on Pango lineages, see https://www.pango.network/</p>
  
 <p>
 <strong>Arguments:</strong><br>
@@ -55,7 +55,7 @@ file containing centroids of locations that lineages are summarised by, used to 
 
 <strong>Default</strong><br>: 2019-11-01 to present day<br>
 -bmcol/--background-map-column<br>
-column in the background dataset containing geographical information to summarise PANGO lineages by. Must correspond to locations in the centroid file and background map file. <br>
+column in the background dataset containing geographical information to summarise Pango lineages by. Must correspond to locations in the centroid file and background map file. <br>
 
 <strong>Default</strong><br>: --location-column (country by default)<br>
 


### PR DESCRIPTION
I searched for the string ‘PANGO’ in all files with grep, so I think this is comprehensive.

I only changed text strings, not any HTML tags or anything, so hopefully the changes do not cause any build/deploy problems.

I left the resources/pangolin/output.html file unchanged, based on the convention for upper-case version identifiers (PANGO-1.2, PLEARN-1.2, PUSHER-1.2).