### PR TITLE
update pango.network links to web.archive.org mirror

### DIFF
--- a/FAQ.html
+++ b/FAQ.html
@@ -16,7 +16,7 @@ layout: default
 
 <h1>Frequently asked questions</h1>
 <br>
-<h5>A set of FAQs related to lineages are available <a href="https://www.pango.network/">here</a>, the following are a list of FAQs related to the pangolin software tool and cov-lineages.org website.</h5>
+<h5>A set of FAQs related to lineages are available <a href="https://web.archive.org/web/20240108015319/https://www.pango.network/">here</a>, the following are a list of FAQs related to the pangolin software tool and cov-lineages.org website.</h5>
 <br>
 <h3>Where does the data come from?</h3>
 
@@ -73,7 +73,7 @@ The assignment may change as new designations are made and new releases of the m
 
 The vast majority of the time, an incorrect assignment is down to missing data. A given sequence may be lacking an informative SNP and this can lead to incorrect placement in the pangoLEARN decision tree, or incorrect placement in the UShER protobuf file if running in `--usher` mode (available from pangolin 3.0 onwards). <br><br>
 
-If you have a complete genome sequence and suspect there's something wrong with the assignment model, the model is informed by the data input from <a href="https://github.com/cov-lineages/pango-designation">pango-designation</a>. The lineages are all designated by hand based on evidence in the phylogenetic tree. If you believe a new sequence should be designated as something other than what it's being assigned, users can follow the instructions at <a href="https://www.pango.network/how-does-the-system-work/how-to-suggest-a-new-lineage/">pango.network</a> to submit a lineage update or correction. This involves posting an issue to <a href="https://github.com/cov-lineages/pango-designation">pango-designation</a> where the <a href="https://www.pango.network/committees/committee-structure/">Pango Network Team</a> will respond to and address queries. 
+If you have a complete genome sequence and suspect there's something wrong with the assignment model, the model is informed by the data input from <a href="https://github.com/cov-lineages/pango-designation">pango-designation</a>. The lineages are all designated by hand based on evidence in the phylogenetic tree. If you believe a new sequence should be designated as something other than what it's being assigned, users can follow the instructions at <a href="https://web.archive.org/web/20240108015319/https://www.pango.network/how-does-the-system-work/how-to-suggest-a-new-lineage/">pango.network</a> to submit a lineage update or correction. This involves posting an issue to <a href="https://github.com/cov-lineages/pango-designation">pango-designation</a> where the <a href="https://web.archive.org/web/20240108015319/https://www.pango.network/committees/committee-structure/">Pango Network Team</a> will respond to and address queries. 
 
 </div>
 

--- a/_data/resources.yaml
+++ b/_data/resources.yaml
@@ -83,7 +83,7 @@
   category: Internally Developed Tools
   logourl: polecat.png
 - name: pango.network
-  link: https://pango.network
+  link: https://web.archive.org/web/20240108015319/https://pango.network
   description: A website documenting the Pango nomenclature as well as the policies involved with designating new lineages.
   subheading: website
   category: Internally Developed Tools

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -2,11 +2,9 @@
 
 <h3>For Questions About Pango Lineages</h3>
 <div class="contrib">
-	Please first check that your question is not answered in the <a href="./FAQ.html">cov-lineages FAQ page</a> or in the <a href="https://www.pango.network/faqs/">Pango network FAQ page</a>.<br><br>
+	Please first check that your question is not answered in the <a href="./FAQ.html">cov-lineages FAQ page</a> or in the <a href="https://web.archive.org/web/20240108015319/https://www.pango.network/faqs/">Pango network FAQ page</a>.<br><br>
 
-	If you are reaching out regarding a SARS-CoV-2 cluster you believe should be designated as a lineage, please file an issue in the <a href="https://github.com/cov-lineages/pango-designation">pango-designation repository</a>. Instructions on how to file an issue can be found <a href="https://www.pango.network/how-does-the-system-work/how-to-suggest-a-new-lineage/">here</a>.<br><br>
-
-	Otherwise, enquiries should be sent to enquiries@pango.network.
+	If you are reaching out regarding a SARS-CoV-2 cluster you believe should be designated as a lineage, please file an issue in the <a href="https://github.com/cov-lineages/pango-designation">pango-designation repository</a>. Instructions on how to file an issue can be found <a href="https://web.archive.org/web/20240108015319/https://www.pango.network/how-does-the-system-work/how-to-suggest-a-new-lineage/">here</a>.<br><br>
 </div>
 <h3>For Questions About Pangolin</h3>
 <div class="contrib">

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -9,7 +9,7 @@
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
       <a class="dropdown-item" href="{{'/index.html#about' | absolute_url}}">About</a>
       <a class="dropdown-item" href="{{'/FAQ.html' | absolute_url}}">FAQs</a>
-      <a class="dropdown-item" href="https://www.pango.network/how-does-the-system-work/how-to-suggest-a-new-lineage/">Suggest a New Lineage</a>
+      <a class="dropdown-item" href="https://web.archive.org/web/20240108015319/https://www.pango.network/how-does-the-system-work/how-to-suggest-a-new-lineage/">Suggest a New Lineage</a>
       <a class="dropdown-item" href="{{'/index.html#cite' | absolute_url}}">How to Cite/Publications</a>
       <a class="dropdown-item" href="{{'/index.html#contributors' | absolute_url}}">Contributors</a>
       <a class="dropdown-item" href="{{'/index.html#contact' | absolute_url}}">Contact Us</a>
@@ -53,7 +53,7 @@
                 <ul>
                     <li><a class="nested-nav-item" href="{{'/index.html#about' | absolute_url}}">About</a></li>
                     <li><a class="nested-nav-item" href="{{'/FAQ.html' | absolute_url}}">FAQs</a></li>
-                    <li><a class="nested-nav-item" href="https://www.pango.network/how-does-the-system-work/how-to-suggest-a-new-lineage/">Suggest a New Lineage</a></li>
+                    <li><a class="nested-nav-item" href="https://web.archive.org/web/20240108015319/https://www.pango.network/how-does-the-system-work/how-to-suggest-a-new-lineage/">Suggest a New Lineage</a></li>
                     <li><a class="nested-nav-item" href="{{'/index.html#cite' | absolute_url}}">How to Cite/Publications</a></li>
                     <li><a class="nested-nav-item" href="{{'/index.html#contributors' | absolute_url}}">Contributors</a></li>
                     <li><a class="nested-nav-item" href="{{'/index.html#contact' | absolute_url}}">Contact Us</a></li>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ title: Home
 
 
 
-<div id="logo_1"><img src="https://www.pango.network/wp-content/uploads/2021/05/pango-network-logo.png"/></div>
+<div id="logo_1"><img src="https://web.archive.org/web/20240108015319/https://www.pango.network/wp-content/uploads/2021/05/pango-network-logo.png"/></div>
 <div id="logo_2"><img src="https://efi.ed.ac.uk/wp-content/uploads/2017/08/Edinburgh-Futures-Institute_white.png"/></div>
 
 <div id="splash_text"><span><span id="pango-title">Pango</span> Lineages: <br> Latest epidemiological lineages of SARS-CoV-2<p class="splash_arrow icon dripicons-chevron-down"></p></span></div>
@@ -64,7 +64,7 @@ title: Home
 			<br>
 
 			<div class="contrib">
-				<center><h5>For more information on the process by which these lineages are discovered and designated, visit <a href="https://pango.network">pango.network</a></h5></center>
+				<center><h5>For more information on the process by which these lineages are discovered and designated, visit <a href="https://web.archive.org/web/20240108015319/https://pango.network">pango.network</a></h5></center>
 			</div>
 
 			</p>

--- a/resources/civet/map_options.html
+++ b/resources/civet/map_options.html
@@ -42,7 +42,7 @@ Arguments:<br>
 
 <p>This option summarises the Pango lineages as radial charts during a set time period at a specific geographical level. Only lineages that make up more than 5% of the overall sequence count are shown, with others shown under “other”.</p>
  
-<p>For more information on Pango lineages, see https://www.pango.network/</p>
+<p>For more information on Pango lineages, see https://web.archive.org/web/20240108015319/https://www.pango.network/</p>
  
 <p>
 <strong>Arguments:</strong><br>


### PR DESCRIPTION
Update pango.network links to point to web.archive.org.  Remove suggestion to email enquiries@pango.network.  fixes #35