### PR TITLE
pangolin installation: change defaults channel to nodefaults.

### DIFF
--- a/resources/pangolin/installation.html
+++ b/resources/pangolin/installation.html
@@ -9,7 +9,10 @@ layout: default
 <h2>Using Bioconda or Mamba</h2>
 
 <ol class="listWithCode">
-	<li> Install using <a href="https://docs.conda.io/en/latest/miniconda.html">conda</a> (or <a href="https://mamba.readthedocs.io/en/latest/installation.html">mamba</a>)<br><br><span class="code">conda install -c bioconda -c conda-forge -c defaults pangolin</span></li>
+	<li> Install using <a href="https://docs.conda.io/en/latest/miniconda.html">conda</a> (or <a href="https://mamba.readthedocs.io/en/latest/installation.html">mamba</a>) in a new environment named pangolin<br><br>
+          <span class="code">conda create -c conda-forge -c bioconda -c nodefaults -n pangolin pangolin</span></li>
+        <li> Activate the pangolin environment<br><br>
+          <span class="code">conda activate pangolin</span></li>
 	<li> Try it out <span class="code">pangolin -h</span></li>
 </ol>
 


### PR DESCRIPTION
@ammaraziz pointed out in cov-lineages/pangolin#562 that the Anaconda defaults channel is unnecessary for building pangolin and can be problematic, so use `-c nodefaults` instead.  Also as Ammar suggested, show how to install pangolin in a newly created conda environment.